### PR TITLE
Fix net_conv_after_unet docstring

### DIFF
--- a/stardist/model.py
+++ b/stardist/model.py
@@ -132,7 +132,7 @@ class Config(argparse.Namespace):
         Number of convolution kernels (feature channels) for first U-Net layer.
         Doubled after each down-sampling layer.
     net_conv_after_unet : int
-        Number of extra convolution layers after U-Net (0 to disable).
+        Number of filters of the extra convolution layer after U-Net (0 to disable).
     train_shape_completion : bool
         Train model to predict complete shapes for partially visible objects at image boundary.
     train_completion_crop : int


### PR DESCRIPTION
The net_conv_after_unet attribute of the stardist config object doesn't describe the number of convolutional layers after the U-Net but the number of filters of the convolutional layer after the U-Net.