### PR TITLE
change model.predict to work for multi-channel img

### DIFF
--- a/stardist/model.py
+++ b/stardist/model.py
@@ -450,10 +450,13 @@ class StarDist(object):
 
         img.ndim in (2,3) or _raise(ValueError())
 
-        channel = img.ndim if backend_channels_last() else 0
+        
         x = img
         if x.ndim == 2:
             x = np.expand_dims(x,channel)
+            
+        channel = img.ndim-1 if backend_channels_last() else 0
+        
         self.config.n_channel_in == x.shape[channel] or _raise(ValueError())
 
         # resize: make divisible by power of 2 to allow downsampling steps in unet


### PR DESCRIPTION
just a short (potential) fix for multi-channel images.