### PR TITLE
KDTree for accelerating NMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This repository contains the implementation of star-convex object detection for 
 International Conference on Medical Image Computing and Computer-Assisted Intervention (MICCAI), Granada, Spain, September 2018.
 
 - Martin Weigert, Uwe Schmidt, Robert Haase, Ko Sugawara, and Gene Myers.  
-[*Star-convex Polyhedra for 3D Object Detection and Segmentation in Microscopy*](https://arxiv.org/abs/1908.03636).  
-arXiv, 2019
+[*Star-convex Polyhedra for 3D Object Detection and Segmentation in Microscopy*](http://openaccess.thecvf.com/content_WACV_2020/papers/Weigert_Star-convex_Polyhedra_for_3D_Object_Detection_and_Segmentation_in_Microscopy_WACV_2020_paper.pdf).  
+The IEEE Winter Conference on Applications of Computer Vision (WACV), Snowmass Village, Colorado, March 2020
 
 Please [cite the paper(s)](#how-to-cite) if you are using this code in your research.
 
@@ -114,10 +114,11 @@ We currently provide a ImageJ/Fiji plugin that can be used to run pretrained Sta
   doi       = {10.1007/978-3-030-00934-2_30}
 }
 
-@article{weigert2019,
+@inproceedings{weigert2019,
   author    = {Martin Weigert and Uwe Schmidt and Robert Haase and Ko Sugawara and Gene Myers},
   title     = {Star-convex Polyhedra for 3D Object Detection and Segmentation in Microscopy},
-  journal   = {arXiv:1908.03636},
-  year      = {2019}
+  booktitle = {The IEEE Winter Conference on Applications of Computer Vision (WACV)},
+  month     = {March},
+  year      = {2020}
 }
 ```

--- a/stardist/lib/stardist3d.cpp
+++ b/stardist/lib/stardist3d.cpp
@@ -34,6 +34,28 @@ int lists_to_vectors(PyObject *list_of_lists, std::vector<std::vector<long>> **v
 }
 
 
+int arrays_to_vectors(PyArrayObject *array_of_arrays, std::vector<std::vector<long>> **vec_of_vecs) {
+
+  if (PyArray_Check(array_of_arrays)) {
+    (**vec_of_vecs).resize(PyArray_DIM(array_of_arrays, 0));
+
+    for(Py_ssize_t i = 0; i < PyArray_DIM(array_of_arrays, 0); i++) {
+      PyObject *array = PyArray_GETITEM(array_of_arrays, PyArray_GetPtr(array_of_arrays, &i));
+      if (PyArray_Check(array)) {
+        (**vec_of_vecs)[i].resize(PyArray_DIM(array, 0));
+
+        for(Py_ssize_t j = 0; j < PyArray_DIM(array, 0); j++) {
+          PyObject *value = PyArray_GETITEM(array, PyArray_GetPtr((PyArrayObject *)array, &j));
+          long long_value = PyLong_AsLong(value);
+          (**vec_of_vecs)[i][j] = long_value;
+        }
+      }  else {return false; }
+    }
+    return true;
+  } else {return false; }
+}
+
+
 static PyObject* c_non_max_suppression_inds(PyObject *self, PyObject *args) {
 
   PyArrayObject *arr_dist=NULL, *arr_points=NULL,*arr_verts=NULL,*arr_faces=NULL,*arr_scores=NULL;
@@ -52,7 +74,7 @@ static PyObject* c_non_max_suppression_inds(PyObject *self, PyObject *args) {
                         &PyArray_Type, &arr_verts,
                         &PyArray_Type, &arr_faces,
                         &PyArray_Type, &arr_scores,
-                        &lists_to_vectors, &ppairs,
+                        &arrays_to_vectors, &ppairs,
                         &use_bbox,
                         &verbose,
                         &threshold))

--- a/stardist/lib/stardist3d_impl.cpp
+++ b/stardist/lib/stardist3d_impl.cpp
@@ -928,6 +928,7 @@ float diff_time(const std::chrono::time_point<std::chrono::high_resolution_clock
 
 void _COMMON_non_maximum_suppression_sparse(
                     const float* scores, const float* dist, const float* points,
+                    std::vector<std::vector<long>>* pairs,
                     const int n_polys, const int n_rays, const int n_faces, 
                     const float* verts, const int* faces,
                     const float threshold, const int use_bbox, const int verbose, 
@@ -1037,7 +1038,7 @@ void _COMMON_non_maximum_suppression_sparse(
   int count_suppressed_kernel = 0;
   int count_suppressed_rendered = 0;
 
-  int count_call_upper = 0;
+  unsigned long long count_call_upper = 0;
   int count_call_lower = 0;
   int count_call_kernel = 0;
   int count_call_render = 0;
@@ -1102,6 +1103,11 @@ void _COMMON_non_maximum_suppression_sparse(
 
     // compute polyverts
     polyhedron_polyverts(curr_dist, curr_point, verts, n_rays, curr_polyverts);
+
+   // TODO: pairs should be leveraged here
+   // inner loop should only be over the indices in the pairs list for the current polygon
+   // the distance metric is symmetric, so if a pair index is less than the current polygon index, it can
+   // be ignored, as it has already been considered
      
 	 //  inner loop
 	 //  can be parallelized....

--- a/stardist/lib/stardist3d_impl.h
+++ b/stardist/lib/stardist3d_impl.h
@@ -6,6 +6,7 @@ int round_to_int(float);
 
 void _COMMON_non_maximum_suppression_sparse(
                     const float* scores, const float* dist, const float* points,
+                    std::vector<std::vector<long>> * pairs,
                     const int n_polys, const int n_rays, const int n_faces, 
                     const float* verts, const int* faces,
                     const float threshold, const int use_bbox, const int verbose, 

--- a/stardist/nms.py
+++ b/stardist/nms.py
@@ -3,7 +3,7 @@ import numpy as np
 from time import time
 from .utils import _normalize_grid
 
-from scipy.spatial import cKDTree
+from sklearn.neighbors import KDTree
 
 
 
@@ -175,8 +175,8 @@ def non_maximum_suppression_3d_inds(dist, points, rays, scores, thresh=0.5, use_
     points = points[ind]
     scores = scores[ind]
 
-    kdtree = cKDTree(points)
-    pairs  = kdtree.query_ball_tree(kdtree, 2*(np.mean(dist) + np.std(dist)))
+    kdtree = KDTree(points)
+    pairs  = kdtree.query_radius(points, 2*(np.mean(dist) + np.std(dist)))
 
     def _prep(x, dtype):
         return np.ascontiguousarray(x.astype(dtype, copy=False))

--- a/stardist/nms.py
+++ b/stardist/nms.py
@@ -3,6 +3,8 @@ import numpy as np
 from time import time
 from .utils import _normalize_grid
 
+from scipy.spatial import cKDTree
+
 
 
 def non_maximum_suppression(coord, prob, grid=(1,1), b=2, nms_thresh=0.5, prob_thresh=0.5, verbose=False, max_bbox_search=True):
@@ -173,6 +175,9 @@ def non_maximum_suppression_3d_inds(dist, points, rays, scores, thresh=0.5, use_
     points = points[ind]
     scores = scores[ind]
 
+    kdtree = cKDTree(points)
+    pairs  = kdtree.query_ball_tree(kdtree, 2 * np.max(dist))
+
     def _prep(x, dtype):
         return np.ascontiguousarray(x.astype(dtype, copy=False))
 
@@ -184,6 +189,7 @@ def non_maximum_suppression_3d_inds(dist, points, rays, scores, thresh=0.5, use_
                                                 _prep(rays.vertices, np.float32),
                                                 _prep(rays.faces, np.int32),
                                                 _prep(scores, np.float32),
+                                                pairs,
                                                 np.int(use_bbox),
                                                 np.int(verbose),
                                                 np.float32(thresh))

--- a/stardist/nms.py
+++ b/stardist/nms.py
@@ -176,7 +176,7 @@ def non_maximum_suppression_3d_inds(dist, points, rays, scores, thresh=0.5, use_
     scores = scores[ind]
 
     kdtree = cKDTree(points)
-    pairs  = kdtree.query_ball_tree(kdtree, 2 * np.max(dist))
+    pairs  = kdtree.query_ball_tree(kdtree, 2*(np.mean(dist) + np.std(dist)))
 
     def _prep(x, dtype):
         return np.ascontiguousarray(x.astype(dtype, copy=False))


### PR DESCRIPTION
This pull request solves issue #39.

After polygon candidates have been reformatted to parallel lists of 3D points and distances (sorted by probability), I construct a KDTree from the points using scipy.spatial.cKDTree. This takes negligible time for all of my tested cases (a few seconds at most). I then call kdtree.query_ball_tree which returns a list of lists - which is also parallel to points/dists. The _i^th_ sublist contains the points which are sufficiently close to point _i_ to merit comparison in NMS. This query is somewhat time consuming, for the largest case tested (6.32e6 points) it took 23 minutes.

This list of lists is passed to `c_non_max_suppression_inds` using the `O&` option to `PyArg_ParseTuple` and a custom python -> c data types converter function `lists_to_vectors`.

The inner loop of `_COMMON_non_maximum_suppression_sparse` is modified to only iterate over these candidate pairs. This capitalizes on the investment of the previous bounded neighbors query. For the largest tested case it brought NMS time down from 7.5 hours to 20 minutes, while still finding the same set of polygons.

I evaluated NMS time over a wide number of polygon candidates. Here are the results (note the log_10 scale on the vertical axis):
![image](https://user-images.githubusercontent.com/8507206/76974187-45812300-6907-11ea-9500-20257615687a.png)

In all cases except the largest, the number of detected polygons between the baseline method and using the kdtree was exactly the same. For the largest case, the baseline method detected 90535 polygons and the kdtree method detected 90536 polygons. Here is a side by side comparison of a single plane of polygons detected in the largest case for both methods:

<img width="879" alt="full_image_results_side_by_side" src="https://user-images.githubusercontent.com/8507206/76974651-d657fe80-6907-11ea-8c30-641c8ebd6a2e.png">

and an overlay (baseline method in red, with kdtree in green):

<img width="552" alt="full_image_results_comparison_overlay" src="https://user-images.githubusercontent.com/8507206/76974713-ea9bfb80-6907-11ea-9e43-2aac1f70ea6e.png">

Correspondence is exact through the whole stack - I'm not sure where that extra one is - too hard to find by eye :) !


**Some additional notes**
The kdtree query time also scales with number of points, but with a worst case complexity of O(N*logN). For very few points (left side of plot) the query time is negligible (milliseconds) - so the kdtree doesn't hurt in those cases.

The O(N*logN) query time for the kdtree could also be reduced to O(C*logN) where C is a constant strictly smaller than N, using a better implementation. Currently, I'm building the kdtree in python, running the bounded neighbors query _for all points_ and then passing the result to the C++ code. Some of these points get suppressed before their bounded neighbors lists are used, and thus computing their bounded neighbors was a waste. If the kdtree data structure was directly accessible in the C++ code, you would instead want to query for bounded neighbors of each individual point at the start of the inner loop of NMS. That way, points which were already suppressed never need to be queried; I think this would cut the query time in half at least. It's a bit more tricky to implement, but definitely possible. I would probably grab the cKDTree implementation from scipy and start from there.

The one extra polygon detected for the largest test case illustrates an interesting aspect of the kdtree.query_ball_tree (bounded neighbors) search. You must provide an upper bound. You can guarantee that any polygon which _could_ be suppressed by a point is included in it's bounded neighbors list by using `2 * np.max(dists)` as the upper bound (any polygons further than that can not possibly overlap), but this results in a pretty long query time, though likely still an overall gain compared to NMS w/o the kdtree. The current choice is `2 * (np.mean(dists) + np.std(dists))` which gives acceptable results for my dataset and is a bit quicker than the max - so I've stuck with it.