### PR TITLE
Force Tuple recast

### DIFF
--- a/stardist/models/base.py
+++ b/stardist/models/base.py
@@ -92,7 +92,7 @@ class StarDistDataBase(RollingSequence):
         if isinstance(X, (np.ndarray, tuple, list)) and \
            isinstance(Y, (np.ndarray, tuple, list)):
             all(y.ndim==nD and x.ndim==x_ndim and x.shape[:nD]==y.shape for x,y in zip(X,Y)) or _raise("images and masks should have corresponding shapes/dimensions")
-            all(x.shape[:nD]>=patch_size for x in X) or _raise("Some images are too small for given patch_size {patch_size}".format(patch_size=patch_size))
+            all(x.shape[:nD]>=tuple(patch_size) for x in X) or _raise("Some images are too small for given patch_size {patch_size}".format(patch_size=patch_size))
 
         if x_ndim == nD:
             self.n_channel = None


### PR DESCRIPTION
Found a small bug on Continuous training, when the model is reloaded, the `model.config.patch_size` is loaded as a list. But the code needs a tuple on training for it to work. 
I fixed it recasting the config prior to training like so `model.config.patch_size = tuple(model.config.patch_size)` 

I here propose to force the patch_size to be a tuple by recasting it for the one check that needs it.